### PR TITLE
fix(workspace:command-line) add --fork-point arg to git merge

### DIFF
--- a/packages/workspace/src/command-line/shared.ts
+++ b/packages/workspace/src/command-line/shared.ts
@@ -45,7 +45,7 @@ function getUntrackedFiles(): string[] {
 }
 
 function getFilesUsingBaseAndHead(base: string, head: string): string[] {
-  const mergeBase = execSync(`git merge-base ${base} ${head}`, {
+  const mergeBase = execSync(`git merge-base --fork-point ${base} ${head} `, {
     maxBuffer: TEN_MEGABYTES,
   })
     .toString()


### PR DESCRIPTION
this fixes getFilesUsingBaseAndHead output in some forking scenarios.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
fails in some scenarios on this call stack
````
[11:39 AM] Yosef, Dror
    Hi, are you familiar of this issue? Trying to run "yarn run ci" on release-mp/12.4.1.0 on monorepo.


$ yarn run ci
yarn run v1.22.4
$ yarn affected:lint && yarn affected:test && yarn affected:apps:production
$ node ci_run.js --target=lint
current branch: release-mp/12.4.1.0


comparing current HEAD to origin/master
D:\Data\client-workspace\node_modules\@nrwl\workspace\node_modules\yargs\yargs.js:1109
      else throw err
           ^


Error: Command failed: git merge-base origin/master HEAD
    at checkExecSyncError (child_process.js:630:11)
    at Object.execSync (child_process.js:666:15)
    at getFilesUsingBaseAndHead (D:\Data\client-workspace\node_modules\@nrwl\workspace\src\command-line\shared.js:47:39)
    at Object.parseFiles (D:\Data\client-workspace\node_modules\@nrwl\workspace\src\command-line\shared.js:32:20)
    at Object.affected (D:\Data\client-workspace\node_modules\@nrwl\workspace\src\command-line\affected.js:20:108)
    at Object.handler (D:\Data\client-workspace\node_modules\@nrwl\workspace\src\command-line\nx-commands.js:47:142)
    at Object.runCommand (D:\Data\client-workspace\node_modules\@nrwl\workspace\node_modules\yargs\lib\command.js:235:44)
    at Object.parseArgs [as _parseArgs] (D:\Data\client-workspace\node_modules\@nrwl\workspace\node_modules\yargs\yargs.js:1022:30)
    at Object.get [as argv] (D:\Data\client-workspace\node_modules\@nrwl\workspace\node_modules\yargs\yargs.js:965:21)
    at Object.initLocal (D:\Data\client-workspace\node_modules\@nrwl\cli\lib\init-local.js:24:13) {
  status: 1,
  signal: null,
  output: [ null, <Buffer >, <Buffer > ],
  pid: 28996,
  stdout: <Buffer >,
  stderr: <Buffer >
}

````

## Expected Behavior
affected commands should work in all forking scenarios
## Related Issue(s)
see https://github.com/nrwl/nx/issues/3274
Fixes #
https://github.com/nrwl/nx/issues/3274